### PR TITLE
Remove KVO Observer before deallocating

### DIFF
--- a/Source/Classes/Gesture/Gesture.swift
+++ b/Source/Classes/Gesture/Gesture.swift
@@ -34,6 +34,7 @@ public final class Gesture<Recognizer: UIGestureRecognizer>: NSObject, UIGesture
     
     deinit {
         self.view = nil
+        self.recognizer.removeObserver(self, forKeyPath: "view")
         self.recognizer = nil
         self.handler = nil
         self.shouldRecognizeSimultaneouslyWithOtherGestures = nil


### PR DESCRIPTION
We experienced a crash when deallocating GestureRecognizers, specifically on iOS 10 devices.

Crash report reads as follows:

>Fatal Exception: NSInternalInconsistencyException
>An instance 0x1703a5a20 of class UITapGestureRecognizer was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x17023d8c0> ( <NSKeyValueObservance 0x170651fd0: Observer: 0x17045fb60, Key path: view, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0, Property: 0x17044f720> )

Full stack trace:
```
Fatal Exception: NSInternalInconsistencyException
0  CoreFoundation                 0x18a8fafe0 __exceptionPreprocess
1  libobjc.A.dylib                0x18935c538 objc_exception_throw
2  CoreFoundation                 0x18a8faf28 -[NSException initWithCoder:]
3  Foundation                     0x18b356120 NSKVODeallocate
4  Sensitive                      0x1011b7f54 Gesture.__deallocating_deinit (Gesture.swift:38)
5  Sensitive                      0x1011b7fe8 @objc Gesture.__deallocating_deinit (<compiler-generated>)
6  Tingles                        0x1002159fc ArtistTableViewCell.prepareForReuse() (ArtistTableViewCell.swift:150)
7  Tingles                        0x100215aa8 @objc ArtistTableViewCell.prepareForReuse() (<compiler-generated>)
8  UIKit                          0x190b694b4 -[UITableView _dequeueReusableViewOfType:withIdentifier:]
9  Tingles                        0x1003aa3a8 __32+[UITableView(TLTableView) load]_block_invoke_2.69
10 UIKit                          0x190ba3cc8 -[UITableView dequeueReusableCellWithIdentifier:forIndexPath:]
11 Tingles                        0x1003aa138 __32+[UITableView(TLTableView) load]_block_invoke_2.38
12 JSQDataSourcesKit              0x1009edd00 @objc UITableView.dequeueReusableCellFor(identifier:indexPath:) (ViewFactory.swift:84)
13 JSQDataSourcesKit              0x1009ed494 ReusableViewFactoryProtocol<>.tableCellFor(item:tableView:indexPath:) (ViewFactory.swift:224)
14 JSQDataSourcesKit              0x1009e7498 closure #3 in DataSourceProvider<>.tableViewBridgedDataSource()
15 JSQDataSourcesKit              0x1009e7af8 partial apply for closure #3 in DataSourceProvider<>.collectionViewBridgedDataSource()
16 JSQDataSourcesKit              0x1009e24e0 @objc BridgedDataSource.collectionView(_:cellForItemAt:)
17 UIKit                          0x190d711f8 -[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]
18 UIKit                          0x190d71410 -[UITableView _createPreparedCellForGlobalRow:willDisplay:]
19 UIKit                          0x190d5eb14 -[UITableView _updateVisibleCellsNow:isRecursive:]
20 UIKit                          0x190d76400 -[UITableView _performWithCachedTraitCollection:]
21 UIKit                          0x190b0e858 -[UITableView layoutSubviews]
22 UIKit                          0x190a2907c -[UIView(CALayerDelegate) layoutSublayersOfLayer:]
23 QuartzCore                     0x18dc19274 -[CALayer layoutSublayers]
24 QuartzCore                     0x18dc0dde8 CA::Layer::layout_if_needed(CA::Transaction*)
25 QuartzCore                     0x18dc0dca8 CA::Layer::layout_and_display_if_needed(CA::Transaction*)
26 QuartzCore                     0x18db8934c CA::Context::commit_transaction(CA::Transaction*)
27 QuartzCore                     0x18dbb03ac CA::Transaction::commit()
28 QuartzCore                     0x18dbb0e78 CA::Transaction::observer_callback(__CFRunLoopObserver*, unsigned long, void*)
29 CoreFoundation                 0x18a8a89a8 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__
30 CoreFoundation                 0x18a8a6630 __CFRunLoopDoObservers
31 CoreFoundation                 0x18a8a6a7c __CFRunLoopRun
32 CoreFoundation                 0x18a7d6da4 CFRunLoopRunSpecific
33 GraphicsServices               0x18c240074 GSEventRunModal
34 UIKit                          0x190a91058 UIApplicationMain
35 Tingles                        0x1000db73c main (ActionControllerExtension.swift:30)
36 libdyld.dylib                  0x1897e559c start
```

Removing the observer before releasing the gesture recognizer fixes this issue.